### PR TITLE
Typo in LiveView documentation: dyamic -> dynamic

### DIFF
--- a/lib/phoenix_live_view.ex
+++ b/lib/phoenix_live_view.ex
@@ -271,7 +271,7 @@ defmodule Phoenix.LiveView do
 
   When you first render a `.leex` template, it will send all of the
   static and dynamic parts of the template to the client. After that,
-  any change you do on the server will now send only the dyamic parts
+  any change you do on the server will now send only the dynamic parts
   and only if those parts have changed.
 
   The tracking of changes are done via assigns. Imagine this template:


### PR DESCRIPTION
Fix tiny spelling error on Line 274: dyamic -> dynamic